### PR TITLE
Resolves GH-14: Fix no includes filtering all values

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -12,3 +12,5 @@ org.slf4j:slf4j-simple:1.7.26,runtime,testRuntime
 org.starchartlabs.alloy:alloy-core:0.5.0,compile
 
 org.testng:testng:6.14.3,testCompile
+
+uk.org.lidalia:slf4j-test:1.2.0,testCompile

--- a/helsing-cli/.gitignore
+++ b/helsing-cli/.gitignore
@@ -3,3 +3,4 @@
 /.settings/
 /build/
 /bin/
+/test-output/

--- a/helsing-cli/build.gradle
+++ b/helsing-cli/build.gradle
@@ -2,6 +2,13 @@ apply plugin: 'it.gianluz.capsule'
 
 description = 'Command line interface for running necromancer utilities on a code set'
 
+//Need to exclude the real logger from test runs, so use a special configuration to side-step its inclusion in test runs
+configurations {
+    capsuleRuntime{
+        extendsFrom runtime
+    }
+}
+
 //Dependency versions managed in ${rootDir}/dependencies.properties
 dependencies {
 	compileOnly 'com.google.code.findbugs:jsr305'
@@ -14,7 +21,18 @@ dependencies {
     compile 'org.slf4j:slf4j-api'
     compile 'org.starchartlabs.alloy:alloy-core'
     
-    runtime 'org.slf4j:slf4j-simple'
+    capsuleRuntime 'org.slf4j:slf4j-simple'
+    
+    testCompile 'org.testng:testng'
+    testCompile 'uk.org.lidalia:slf4j-test'
+    
+    testRuntime project(':helsing-test-project')
+}
+
+// Configure tests with directory for test project
+// This requires setting up TestNG run/debug properties within IDE imports to execute tests
+test {
+    systemProperty 'org.starchartlabs.helsing.test.project.dir', "${project(':helsing-test-project').projectDir}"
 }
 
 //Apply module naming to all projects
@@ -34,7 +52,7 @@ javadocJar{
 
 task distCapsule(type: FatCapsule) {
     applicationClass 'org.starchartlabs.helsing.cli.CommandLineInterface'
-    embedConfiguration configurations.runtime
+    embedConfiguration configurations.capsuleRuntime
 }
 
 tasks.assemble.dependsOn distCapsule

--- a/helsing-cli/src/main/java/org/starchartlabs/helsing/cli/command/DeadClassCandidatesCommand.java
+++ b/helsing-cli/src/main/java/org/starchartlabs/helsing/cli/command/DeadClassCandidatesCommand.java
@@ -99,7 +99,6 @@ public class DeadClassCandidatesCommand implements Runnable {
 
     private Predicate<Path> getIncludeFilter() {
         Set<String> classFileNamePatterns = toClassPatterns(includePatterns);
-
         classFileNamePatterns.forEach(pattern -> logger.info("Inclusion match pattern provided: '{}'", pattern));
 
         Collection<PathMatcher> matchers = classFileNamePatterns.stream()
@@ -107,7 +106,7 @@ public class DeadClassCandidatesCommand implements Runnable {
                 .map(pattern -> FileSystems.getDefault().getPathMatcher("glob:" + pattern))
                 .collect(Collectors.toList());
 
-        return (filePath -> matchers.stream().anyMatch(matcher -> matcher.matches(filePath)));
+        return (filePath -> matchers.isEmpty() || matchers.stream().anyMatch(matcher -> matcher.matches(filePath)));
     }
 
     private Predicate<Path> getExcludeFilter() {

--- a/helsing-cli/src/test/java/org/starchartlabs/helsing/test/cli/command/DeadClassCandidatesCommandTest.java
+++ b/helsing-cli/src/test/java/org/starchartlabs/helsing/test/cli/command/DeadClassCandidatesCommandTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) Feb 11, 2020 StarChart Labs Authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ */
+package org.starchartlabs.helsing.test.cli.command;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
+import org.starchartlabs.helsing.cli.CommandLineInterface;
+import org.starchartlabs.helsing.cli.command.DeadClassCandidatesCommand;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import uk.org.lidalia.slf4jext.Level;
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+
+public class DeadClassCandidatesCommandTest {
+
+    private static final Path TEST_PROJECT_DIRECTORY = Paths
+            .get(System.getProperty("org.starchartlabs.helsing.test.project.dir"));
+
+    private static final List<String> CLASS_NAMES = new ArrayList<>();
+
+    static {
+        CLASS_NAMES.add("org.starchartlabs.helsing.test.project.ClassAnnotation");
+        CLASS_NAMES.add("org.starchartlabs.helsing.test.project.DeadClass");
+        CLASS_NAMES.add("org.starchartlabs.helsing.test.project.FieldAnnotation");
+        CLASS_NAMES.add("org.starchartlabs.helsing.test.project.MethodAnnotation");
+        CLASS_NAMES.add("org.starchartlabs.helsing.test.project.UsedByAnnotationConstantFullName");
+        CLASS_NAMES.add("org.starchartlabs.helsing.test.project.UsedByAnnotationConstantSimpleName");
+        CLASS_NAMES.add("org.starchartlabs.helsing.test.project.UsedByConstantFullName");
+        CLASS_NAMES.add("org.starchartlabs.helsing.test.project.UsedByConstantSimpleName");
+        CLASS_NAMES.add("org.starchartlabs.helsing.test.project.UsedViaExtension");
+        CLASS_NAMES.add("org.starchartlabs.helsing.test.project.UsedViaSimpleMethod");
+        CLASS_NAMES.add("org.starchartlabs.helsing.test.project.UsedViaStaticMethod");
+        CLASS_NAMES.add("org.starchartlabs.helsing.test.project.UsesOtherClasses");
+        CLASS_NAMES.add("org.starchartlabs.helsing.test.project.other.UsedByConstantFullName");
+        CLASS_NAMES.add("org.starchartlabs.helsing.test.project.other.UsedByConstantImported");
+    }
+
+    private final TestLogger testLogger = TestLoggerFactory.getTestLogger(DeadClassCandidatesCommand.class);
+
+    @BeforeMethod
+    public void resetTestLogger() {
+        testLogger.clear();
+    }
+
+    @Test
+    public void basicAnalysis() throws Exception {
+        List<String> expectedDeadClasses = Arrays.asList(
+                "org.starchartlabs.helsing.test.project.DeadClass",
+                "org.starchartlabs.helsing.test.project.UsesOtherClasses");
+
+        String[] args = new String[] { DeadClassCandidatesCommand.COMMAND_NAME, "--directory=" + TEST_PROJECT_DIRECTORY };
+
+        try {
+            CommandLineInterface.main(args);
+        } finally {
+            // Expect the known dead class, and external API class (not marked as such), to be marked as dead
+            List<String> events = testLogger.getLoggingEvents().stream()
+                    .filter(event -> Level.INFO.equals(event.getLevel()))
+                    .map(event -> MessageFormatter.arrayFormat(event.getMessage(), event.getArguments().toArray()))
+                    .map(FormattingTuple::getMessage)
+                    .collect(Collectors.toList());
+
+            Assert.assertTrue(events.contains("Found 2 classes with no detected references"),
+                    "Expected 2 classes marked as dead " + events);
+
+            CLASS_NAMES.stream()
+            .filter(a -> !expectedDeadClasses.contains(a))
+            .forEach(className -> {
+                Assert.assertFalse(events.contains("No references found to class " + className),
+                        "Did not expext class " + className + " to be marked as dead " + events);
+            });
+
+            CLASS_NAMES.stream()
+            .filter(expectedDeadClasses::contains)
+            .forEach(className -> {
+                Assert.assertTrue(events.contains("No references found to class " + className),
+                        "Expect class " + className + " to be marked as dead " + events);
+            });
+        }
+    }
+
+    @Test
+    public void withIncludeFilter() throws Exception {
+        List<String> expectedDeadClasses = Arrays.asList(
+                "org.starchartlabs.helsing.test.project.other.UsedByConstantFullName",
+                "org.starchartlabs.helsing.test.project.other.UsedByConstantImported");
+
+        String[] args = new String[] { DeadClassCandidatesCommand.COMMAND_NAME, "--directory=" + TEST_PROJECT_DIRECTORY,
+        "--include=org.starchartlabs.helsing.test.project.other.*" };
+
+        try {
+            CommandLineInterface.main(args);
+        } finally {
+            // Expect both classes, as the class that uses them is not included in the analysis
+            List<String> events = testLogger.getLoggingEvents().stream()
+                    .filter(event -> Level.INFO.equals(event.getLevel()))
+                    .map(event -> MessageFormatter.arrayFormat(event.getMessage(), event.getArguments().toArray()))
+                    .map(FormattingTuple::getMessage)
+                    .collect(Collectors.toList());
+
+            Assert.assertTrue(events.contains("Found 2 classes with no detected references"),
+                    "Expected 2 classes marked as dead " + events);
+
+            CLASS_NAMES.stream()
+            .filter(a -> !expectedDeadClasses.contains(a))
+            .forEach(className -> {
+                Assert.assertFalse(events.contains("No references found to class " + className),
+                        "Did not expext class " + className + " to be marked as dead " + events);
+            });
+
+            CLASS_NAMES.stream()
+            .filter(expectedDeadClasses::contains)
+            .forEach(className -> {
+                Assert.assertTrue(events.contains("No references found to class " + className),
+                        "Expect class " + className + " to be marked as dead " + events);
+            });
+        }
+    }
+
+    @Test
+    public void withExcludeFilter() throws Exception {
+        List<String> expectedDeadClasses = Arrays.asList(
+                "org.starchartlabs.helsing.test.project.UsesOtherClasses");
+
+        String[] args = new String[] { DeadClassCandidatesCommand.COMMAND_NAME, "--directory=" + TEST_PROJECT_DIRECTORY,
+        "--exclude=**.DeadClass" };
+
+        try {
+            CommandLineInterface.main(args);
+        } finally {
+            // Expect the external API class (not marked as such), to be marked as dead - known dead class should not
+            // be, as it was excluded
+            List<String> events = testLogger.getLoggingEvents().stream()
+                    .filter(event -> Level.INFO.equals(event.getLevel()))
+                    .map(event -> MessageFormatter.arrayFormat(event.getMessage(), event.getArguments().toArray()))
+                    .map(FormattingTuple::getMessage)
+                    .collect(Collectors.toList());
+
+            Assert.assertTrue(events.contains("Found 1 classes with no detected references"),
+                    "Expected 1 classes marked as dead " + events);
+
+            CLASS_NAMES.stream()
+            .filter(a -> !expectedDeadClasses.contains(a))
+            .forEach(className -> {
+                Assert.assertFalse(events.contains("No references found to class " + className),
+                        "Did not expext class " + className + " to be marked as dead " + events);
+            });
+
+            CLASS_NAMES.stream()
+            .filter(expectedDeadClasses::contains)
+            .forEach(className -> {
+                Assert.assertTrue(events.contains("No references found to class " + className),
+                        "Expect class " + className + " to be marked as dead " + events);
+            });
+        }
+    }
+
+    @Test
+    public void withExternalApi() throws Exception {
+        List<String> expectedDeadClasses = Arrays.asList("org.starchartlabs.helsing.test.project.DeadClass");
+
+        String[] args = new String[] { DeadClassCandidatesCommand.COMMAND_NAME, "--directory=" + TEST_PROJECT_DIRECTORY,
+        "--external=org.starchartlabs.helsing.test.project.UsesOtherClasses" };
+
+        try {
+            CommandLineInterface.main(args);
+        } finally {
+            // Expect the known dead class - external API class is marked as such
+            List<String> events = testLogger.getLoggingEvents().stream()
+                    .filter(event -> Level.INFO.equals(event.getLevel()))
+                    .map(event -> MessageFormatter.arrayFormat(event.getMessage(), event.getArguments().toArray()))
+                    .map(FormattingTuple::getMessage)
+                    .collect(Collectors.toList());
+
+            Assert.assertTrue(events.contains("Found 1 classes with no detected references"),
+                    "Expected 1 classes marked as dead " + events);
+
+            CLASS_NAMES.stream()
+            .filter(a -> !expectedDeadClasses.contains(a))
+            .forEach(className -> {
+                Assert.assertFalse(events.contains("No references found to class " + className),
+                        "Did not expext class " + className + " to be marked as dead " + events);
+            });
+
+            CLASS_NAMES.stream()
+            .filter(expectedDeadClasses::contains)
+            .forEach(className -> {
+                Assert.assertTrue(events.contains("No references found to class " + className),
+                        "Expect class " + className + " to be marked as dead " + events);
+            });
+        }
+    }
+
+}

--- a/helsing-core/build.gradle
+++ b/helsing-core/build.gradle
@@ -9,8 +9,6 @@ dependencies {
     compile 'org.slf4j:slf4j-api'
     compile 'org.starchartlabs.alloy:alloy-core'
     
-    runtime 'org.slf4j:slf4j-simple'
-
     testCompile 'org.testng:testng'
     
     testRuntime project(':helsing-test-project')


### PR DESCRIPTION
When include filtering was added, the CLI command's handling did not
account for "no include filters" properly - excluding all files instead
of ignoring the lack of include values.

This change set fixes handling to not filter any files via include logic
if no include filters are present, and adds basic CLI-level automated
tests